### PR TITLE
Re-instate gnulib patch

### DIFF
--- a/patches/gnulib.patch
+++ b/patches/gnulib.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/fdopendir.c b/lib/fdopendir.c
+index 0f43d6f..015163d 100644
+--- a/lib/fdopendir.c
++++ b/lib/fdopendir.c
+@@ -174,7 +174,9 @@ fdopendir_with_dup (int fd, int older_dupfd, struct saved_cwd const *cwd)
+         }
+       else
+         {
++#ifndef __MVS__
+           close (fd);
++#endif
+           dir = fd_clone_opendir (dupfd, cwd);
+           saved_errno = errno;
+           if (! dir)


### PR DESCRIPTION
This patch was removed from the bump update to 3.11. We need it to resolve https://github.com/ZOSOpenTools/grepport/issues/13