### PR TITLE
Fix for excess open file descriptors

### DIFF
--- a/patches/fts.c.patch
+++ b/patches/fts.c.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/fts.c b/lib/fts.c
+index 3fffb45..37e0ccd 100644
+--- a/lib/fts.c
++++ b/lib/fts.c
+@@ -1397,8 +1397,11 @@ fts_build (register FTS *sp, int type)
+                                  != NO_LEAF_OPTIMIZATION)));
+             if (descend || type == BREAD)
+               {
+-                if (ISSET(FTS_CWDFD))
++                if (ISSET(FTS_CWDFD)) {
++                  int old_fd = dir_fd;
+                   dir_fd = fcntl (dir_fd, F_DUPFD_CLOEXEC, STDERR_FILENO + 1);
++                  close(old_fd); // avoid lingering open file descriptors
++                }
+                 if (dir_fd < 0 || fts_safe_changedir(sp, cur, dir_fd, NULL)) {
+                         if (descend && type == BREAD)
+                                 cur->fts_errno = errno;


### PR DESCRIPTION
Same fix as https://github.com/ZOSOpenTools/findutilsport/issues/16